### PR TITLE
Teach bootstrap script to create full file paths

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -69,6 +69,7 @@ bundle exec rake scrape
 bundle exec rake
 
 # start nginx with the right config
+sudo mkdir -p /home/vagrant/umdio/data/nginx/cache # needed to add this line for nginx startup
 sudo sed -i '1i127.0.0.1 api.localhost' /etc/hosts # add a line to hosts file for convenience
 sudo nginx -s stop
 sudo nginx -c /home/vagrant/umdio/nginx.conf


### PR DESCRIPTION
Vagrant provisioning broke on my machine because the specified path didn't exist when nginx tried to start. Hopefully this will help some other unlucky souls!