### PR TITLE
Fixed / improved course description and relationship parsing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,4 +28,5 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 80, host: 4080, auto_correct: true
   config.vm.network :forwarded_port, guest: 3000, host: 3000, auto_correct: true
   config.vm.network :forwarded_port, guest: 4000, host: 4000, auto_correct: true
+  config.vm.network :forwarded_port, guest: 27017, host: 27017 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,5 +28,4 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 80, host: 4080, auto_correct: true
   config.vm.network :forwarded_port, guest: 3000, host: 3000, auto_correct: true
   config.vm.network :forwarded_port, guest: 4000, host: 4000, auto_correct: true
-  config.vm.network :forwarded_port, guest: 27017, host: 27017 
 end

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -62,14 +62,14 @@ dep_urls.each do |url|
   page.search('div.course').each do |course|
     description =  (utf_safe(course.css('div.approved-course-texts-container').text + course.css('div.course-texts-container').text)).strip.gsub(/\t|\r\n/,'')
     relationships = {
-      coreqs: /Corequisite: ([^.]+)/.match(description).to_a[2],
-      prereqs: /Prerequisite: ([^.]+)/.match(description).to_a[2],
-      restrictions: /Restriction: ([^.]+)/.match(description).to_a[2],
-      restricted_to: /Restricted to ([^.]+)/.match(description).to_a[2],
-      credit_only_granted_for: /Credit only granted for:([^.]+)/.match(description).to_a[2],
-      credit_granted_for: /Credit granted for([^.]+)/.match(description).to_a[2],
-      formerly: /Formerly:([^.]+)/.match(description).to_a[2],
-      also_offered_as: /Also offered as([^.]+)/.match(description).to_a[2]
+      coreqs: /Corequisite: ([^.]+)/.match(description).to_a[1],
+      prereqs: /Prerequisite: ([^.]+)/.match(description).to_a[1],
+      restrictions: /Restriction: ([^.]+)/.match(description).to_a[1],
+      restricted_to: /Restricted to ([^.]+)/.match(description).to_a[1],
+      credit_only_granted_for: /Credit only granted for: ([^.]+)/.match(description).to_a[1],
+      credit_granted_for: /Credit granted for ([^.]+)/.match(description).to_a[1],
+      formerly: /Formerly: ([^.]+)/.match(description).to_a[1],
+      also_offered_as: /Also offered as:? ([^.]+)/.match(description).to_a[1]
     } 
 
     course_array << {

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -54,7 +54,7 @@ dep_urls.each do |url|
   dept_id = url.split('/soc/')[1][7,10] 
   semester = url.split('/soc/')[1][0,6] 
   courses = []
-  coll = db.collection('testing')
+  coll = db.collection('courses' + semester)
   bulk = coll.initialize_unordered_bulk_op
 
   puts "Getting courses for #{dept_id} (#{semester})"

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -152,8 +152,7 @@ dep_urls.each do |url|
       department: department,
       semester: semester,
       credits: course.css('span.course-min-credits').first.content,
-      grading_method: course.at_css('span.grading-method abbr') ? 
-              course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
+      grading_method: course.at_css('span.grading-method abbr')&.attr('title')&.split(', ') || [],
       core: utf_safe(course.css('div.core-codes-group').text).gsub(/\s/, '').delete('CORE:').split(','),
       gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:').split(','),
       description: description,

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -53,45 +53,117 @@ end
 dep_urls.each do |url|
   dept_id = url.split('/soc/')[1][7,10] 
   semester = url.split('/soc/')[1][0,6] 
-  course_array = []
-  coll = db.collection('courses' + semester)
+  courses = []
+  coll = db.collection('testing')
   bulk = coll.initialize_unordered_bulk_op
-  page = Nokogiri::HTML(open(url))
+
+  puts "Getting courses for #{dept_id} (#{semester})"
+
+  page = Nokogiri::HTML(open(url), nil, "UTF-8")
+
   department = page.search('span.course-prefix-name').text.strip
 
-  page.search('div.course').each do |course|
-    description =  (utf_safe(course.css('div.approved-course-texts-container').text + course.css('div.course-texts-container').text)).strip.gsub(/\t|\r\n/,'')
-    relationships = {
-      coreqs: /Corequisite: ([^.]+)/.match(description).to_a[1],
-      prereqs: /Prerequisite: ([^.]+)/.match(description).to_a[1],
-      restrictions: /Restriction: ([^.]+)/.match(description).to_a[1],
-      restricted_to: /Restricted to ([^.]+)/.match(description).to_a[1],
-      credit_only_granted_for: /Credit only granted for: ([^.]+)/.match(description).to_a[1],
-      credit_granted_for: /Credit granted for ([^.]+)/.match(description).to_a[1],
-      formerly: /Formerly: ([^.]+)/.match(description).to_a[1],
-      also_offered_as: /Also offered as:? ([^.]+)/.match(description).to_a[1]
-    } 
 
-    course_array << {
-      course_id: course.search('div.course-id').text,
-      name: course.css('span.course-title').first.content,
+  page.search('div.course').each { |course|
+    course_id = course.search('div.course-id').text
+    course_title = course.search('span.course-title').text
+    credits = course.search('span.course-min-credits').text
+
+    # courses have 2 'course texts': approved-course-texts and course-texts
+    # approved-course-texts has 2 child divs: relationships and description (if there are any relationships)
+    # other course-texts will have relationships mixed in with description
+    # 
+    # if course has both approved-course-text and course-texts, only first set of 
+    #     relationships will be parsed. anything in course-texts will be placed in "additional info"
+    #
+    # algorithm finds relationships and, if they exist, removes them from the description
+    # searches both approved-course-texts > div:first-child and course-texts > div for relationships
+    # leftover text will either be description (if approved-course-texts is empty) or additional info
+
+    approved = course.search('div.approved-course-texts-container')
+    other = course.search('div.course-texts-container')
+
+    # get all relationship text
+    if approved.css('> div').length > 1 then 
+      text = approved.css('> div:first-child').text.strip + other.css('> div').text.strip
+    else 
+      text = other.css('> div').text.strip
+    end
+
+    text = utf_safe text
+
+    # match all relationships, remove them from the description
+
+    match = /Prerequisite: ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    prereq = match ? match[1] : nil
+
+
+    match = /Corequisite: ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    coreq = match ? match[1] : nil
+
+    match = /(?:Restricted to)|(?:Restriction:) ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    restrictions = match ? match[1] : nil
+
+    match = /Credit (?:(?:only )|(?:will be ))?granted for(?: one of the following)?:? ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    credit_granted_for = match ? match[1] : nil
+
+    match = /Also offered as:? ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    also_offered_as = match ? match[1] : nil
+
+
+    match = /Formerly:? ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    formerly = match ? match[1] : nil
+
+    match = /Additional information: ([^.]+\.)/.match(text)
+    text = match ? text.gsub(match[0], '') : text
+    additional_info = match ? match[1] : nil
+
+    # if approved-course-texts held relationships, use 2nd child as description and leftover text as "additional info"
+    if approved.css('> div').length > 0 then
+
+      description = utf_safe approved.css('> div:last-child').text.strip.gsub(/\t|(\r\n)/, '')
+      additional_info = additional_info ? additional_info += ' '+text : text
+      additional_info = additional_info && additional_info.strip.empty? ? nil : additional_info.strip
+
+    elsif other.css('> div').length > 0 then
+      description = text.strip.empty? ? nil : text.strip
+    end
+
+    relationships = {
+      prereqs: prereq,
+      coreqs: coreq,
+      restrictions: restrictions,
+      credit_granted_for: credit_granted_for,
+      also_offered_as: also_offered_as,
+      formerly: formerly,
+      additional_info: additional_info 
+    }
+
+    courses << {
+      course_id: course_id,
+      name: course_title,
       dept_id: dept_id,
       department: department,
       semester: semester,
       credits: course.css('span.course-min-credits').first.content,
-      grading_method: course.at_css('span.grading-method abbr') ? course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
+      grading_method: course.at_css('span.grading-method abbr') ? 
+              course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
       core: utf_safe(course.css('div.core-codes-group').text).gsub(/\s/, '').delete('CORE:').split(','),
       gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:').split(','),
       description: description,
       relationships: relationships
     }
-
-  end
+  }
   
-  puts "inserting courses from #{dept_id} (#{semester})"
-  # bulk for speed, upsert so it can be run multiple times without worry
-  course_array.each do |course|
+
+  courses.each { |course|
     bulk.find({course_id: course[:course_id]}).upsert.update({ "$set" => course })
-  end
+  }
   bulk.execute
 end

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -64,7 +64,7 @@ dep_urls.each do |url|
   department = page.search('span.course-prefix-name').text.strip
 
 
-  page.search('div.course').each { |course|
+  page.search('div.course').each do |course|
     course_id = course.search('div.course-id').text
     course_title = course.search('span.course-title').text
     credits = course.search('span.course-min-credits').text
@@ -84,7 +84,7 @@ dep_urls.each do |url|
     other = course.search('div.course-texts-container')
 
     # get all relationship text
-    if approved.css('> div').length > 1 then 
+    if approved.css('> div').length > 1 
       text = approved.css('> div:first-child').text.strip + other.css('> div').text.strip
     else 
       text = other.css('> div').text.strip
@@ -125,13 +125,13 @@ dep_urls.each do |url|
     additional_info = match ? match[1] : nil
 
     # if approved-course-texts held relationships, use 2nd child as description and leftover text as "additional info"
-    if approved.css('> div').length > 0 then
+    if approved.css('> div').length > 0 
 
       description = utf_safe approved.css('> div:last-child').text.strip.gsub(/\t|(\r\n)/, '')
       additional_info = additional_info ? additional_info += ' '+text : text
       additional_info = additional_info && additional_info.strip.empty? ? nil : additional_info.strip
 
-    elsif other.css('> div').length > 0 then
+    elsif other.css('> div').length > 0 
       description = text.strip.empty? ? nil : text.strip
     end
 
@@ -159,11 +159,11 @@ dep_urls.each do |url|
       description: description,
       relationships: relationships
     }
-  }
+  end
   
 
-  courses.each { |course|
+  courses.each do |course|
     bulk.find({course_id: course[:course_id]}).upsert.update({ "$set" => course })
-  }
+  end
   bulk.execute
 end


### PR DESCRIPTION
Regex match at index 2 was always nil as there were only 2 matches: main match and 1 capture group which contained relevant info. Also added small formatting change for "Formerly" and "Also offered as".