### PR TITLE
Removed semester and year hardcoding 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :scrape do
   # if fall is updated, we want to get the next year's courses 
   year = Time.now.month >= 10 || Time.now.month <= 3 ? Time.now.year : Time.now.year + 1
   years = ((year - 3)..year).to_a.join ' '
-  semester = get_current_semester
+  semester = current_semester
   sh "ruby app/scrapers/courses_scraper.rb #{years}"
   sh 'ruby app/scrapers/sections_scraper.rb'
   sh 'ruby app/scrapers/section_course_linker.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
 require 'rspec/core/rake_task'
+require_relative 'app/helpers/courses_helpers.rb'
+
+include Sinatra::UMDIO::Helpers
 #require File.expand_path('../config/application', __FILE__)
  
 namespace :db do
@@ -30,11 +33,16 @@ end
 
 desc "Scrape to fill databases" # takes about 15 minutes
 task :scrape do
-  sh 'ruby app/scrapers/courses_scraper.rb 2013 2014 2015 2016'
+  # Testudo updated in September for Spring, Fed for fall
+  # if fall is updated, we want to get the next year's courses 
+  year = Time.now.month >= 10 || Time.now.month <= 3 ? Time.now.year : Time.now.year + 1
+  years = ((year - 3)..year).each.to_a.join ' '
+  semester = get_current_semester
+  sh "ruby app/scrapers/courses_scraper.rb #{years}"
   sh 'ruby app/scrapers/sections_scraper.rb'
   sh 'ruby app/scrapers/section_course_linker.rb'
   # TODO: don't hardcode semester_id
-  sh 'ruby app/scrapers/update_open_seats.rb 201608'
+  sh "ruby app/scrapers/update_open_seats.rb #{semester}"
   sh 'ruby app/scrapers/bus_routes_scraper.rb'
   sh 'ruby app/scrapers/bus_schedules_scraper_small.rb'
   sh 'ruby app/scrapers/buildings.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ task :scrape do
   # Testudo updated in September for Spring, Fed for fall
   # if fall is updated, we want to get the next year's courses 
   year = Time.now.month >= 10 || Time.now.month <= 3 ? Time.now.year : Time.now.year + 1
-  years = ((year - 3)..year).each.to_a.join ' '
+  years = ((year - 3)..year).to_a.join ' '
   semester = get_current_semester
   sh "ruby app/scrapers/courses_scraper.rb #{years}"
   sh 'ruby app/scrapers/sections_scraper.rb'

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,7 +10,7 @@ module Sinatra
           app.before '/v0/courses*' do
             @special_params = ['sort', 'semester', 'expand', 'per_page', 'page']
 
-            semester = params[:semester] || '201608'
+            semester = params[:semester] || get_current_semester
             check_semester app, semester, 'courses'
 
             @course_coll = app.settings.courses_db.collection("courses#{semester}")

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,7 +10,7 @@ module Sinatra
           app.before '/v0/courses*' do
             @special_params = ['sort', 'semester', 'expand', 'per_page', 'page']
 
-            semester = params[:semester] || get_current_semester
+            semester = params[:semester] || current_semester
             check_semester app, semester, 'courses'
 
             @course_coll = app.settings.courses_db.collection("courses#{semester}")

--- a/app/controllers/professors_controller.rb
+++ b/app/controllers/professors_controller.rb
@@ -10,7 +10,7 @@ module Sinatra
           app.before '/v0/professors*' do
             @special_params = ['sort', 'semester', 'per_page', 'page']
 
-            semester = params[:semester] || get_current_semester
+            semester = params[:semester] || current_semester
             check_semester app, semester, 'profs'
 
             @prof_coll = app.settings.courses_db.collection("profs#{semester}")

--- a/app/controllers/professors_controller.rb
+++ b/app/controllers/professors_controller.rb
@@ -10,7 +10,7 @@ module Sinatra
           app.before '/v0/professors*' do
             @special_params = ['sort', 'semester', 'per_page', 'page']
 
-            semester = params[:semester] || '201608'
+            semester = params[:semester] || get_current_semester
             check_semester app, semester, 'profs'
 
             @prof_coll = app.settings.courses_db.collection("profs#{semester}")

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -173,7 +173,7 @@ module Sinatra
         if month >= 3 && month <= 10
           year.to_s + '08'
         else
-          (year <= 12 ? year + 1 : year).to_s + '01'
+          (month <= 12 ? year + 1 : year).to_s + '01'
         end
       end
 

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -165,13 +165,15 @@ module Sinatra
         time.to_i
       end
 
-      # TODO: make this line up with Testudo accurately and implement it in course controller
       def get_current_semester
-        time = Time.new
-        if time.month >= 3 && time.month < 10
-          time.year.to_s + '08'
+        # Testudo schedules updated mid/late September for Spring, mid/late Feb for fall
+        # advisor calendar found here http://registrar.umd.edu/faculty-staff/
+        month = Time.now.month
+        year = Time.now.year
+        if month >= 3 && month <= 10
+          year.to_s + '08'
         else
-          (time.year + 1).to_s + '01'
+          (year <= 12 ? year + 1 : year).to_s + '01'
         end
       end
 

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -173,7 +173,7 @@ module Sinatra
         if month >= 3 && month <= 10
           year.to_s + '08'
         else
-          (month <= 12 ? year + 1 : year).to_s + '01'
+          ([11,12].include?(month) ? year + 1 : year).to_s + '01'
         end
       end
 

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -165,15 +165,15 @@ module Sinatra
         time.to_i
       end
 
-      def get_current_semester
+      def current_semester
         # Testudo schedules updated mid/late September for Spring, mid/late Feb for fall
         # advisor calendar found here http://registrar.umd.edu/faculty-staff/
         month = Time.now.month
         year = Time.now.year
         if month >= 3 && month <= 10
-          year.to_s + '08'
+          "#{year}08"
         else
-          ([11,12].include?(month) ? year + 1 : year).to_s + '01'
+          "#{([11,12].include?(month) ? year + 1 : year)}01"
         end
       end
 


### PR DESCRIPTION
Based off of when the University updates the SOC (found [here](https://docs.google.com/document/d/1ymAGvxoZ7EYoBmygv5RD1htDHp7rndqxBIWl5Okrrhw/edit)). Looks like historically it's been updated around mid-September for Spring classes and mid-February for Fall classes