### PR TITLE
Improved Gen Ed parsing and querying

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -157,6 +157,19 @@ module Sinatra
             sorting = params_sorting_array 'course_id'
             query   = params_search_query  @special_params
 
+            # use regex instead of just 'gen_ed = DSHS'
+            # now gen ed code may be in the middle of a string (DSHS or DVUP, DSHS if taken with..., etc)
+            if query['gen_ed']
+              new_gened_query = {
+                '$regex': ".*#{query['gen_ed']}.*",
+                '$options': 'i'
+              }
+
+              query['gen_ed'] = new_gened_query
+            end
+
+            p query
+
             courses = @course_coll.find(query, {:sort => sorting, :limit => @limit, :skip => (@page - 1)*@limit, :fields => {:_id => 0}}).map{ |e| e }
             courses = flatten_course_sections_expand @section_coll, courses unless courses.empty?
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -168,8 +168,6 @@ module Sinatra
               query['gen_ed'] = new_gened_query
             end
 
-            p query
-
             courses = @course_coll.find(query, {:sort => sorting, :limit => @limit, :skip => (@page - 1)*@limit, :fields => {:_id => 0}}).map{ |e| e }
             courses = flatten_course_sections_expand @section_coll, courses unless courses.empty?
 

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -135,6 +135,16 @@ dep_urls.each do |url|
       description = text.strip.empty? ? nil : text.strip
     end
 
+    gen_ed = []
+    # remove unnecessary tabs, returns, newlines
+    s = utf_safe(course.css('div.gen-ed-codes-group').text.gsub(/[\t\r\n]/, ''))
+    s = s.gsub('(', ' (').gsub(')', ') ') # fix spacing with parentheses
+    s = s.gsub('or', ' or ') # fix spacing with 'or'
+    s = s.gsub('  ', ' ') # make sure no double spaces
+    s = s.split(':') # ignore 'GenEd:'
+    gen_ed = s[1].split(',') if s.length > 0 # split by commas
+    gen_ed.map! do |x| x.strip end # ignore leading, trailing spaces
+
     relationships = {
       prereqs: prereq,
       coreqs: coreq,
@@ -154,7 +164,7 @@ dep_urls.each do |url|
       credits: course.css('span.course-min-credits').first.content,
       grading_method: course.at_css('span.grading-method abbr') ? course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
       core: utf_safe(course.css('div.core-codes-group').text).gsub(/\s/, '').delete('CORE:').split(','),
-      gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:').split(','),
+      gen_ed: gen_ed,
       description: description,
       relationships: relationships
     }


### PR DESCRIPTION
Addresses [#33](https://github.com/umdio/umdio/issues/33). Accounts for special cases during scraping and still allows users to search for courses with special-case Gen Eds by the 4-letter code.