### PR TITLE
Updating scrape rake task so it scrapes all available semesters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,14 +35,14 @@ desc "Scrape to fill databases" # takes about 15 minutes
 task :scrape do
   # Testudo updated in September for Spring, Fed for fall
   # if fall is updated, we want to get the next year's courses 
-  year = Time.now.month >= 10 || Time.now.month <= 3 ? Time.now.year : Time.now.year + 1
+  year = Time.now.month <= 9 ? Time.now.year : Time.now.year + 1
   years = ((year - 3)..year).to_a.join ' '
-  semester = current_semester
+  semesters = current_and_next_semesters
   sh "ruby app/scrapers/courses_scraper.rb #{years}"
   sh 'ruby app/scrapers/sections_scraper.rb'
   sh 'ruby app/scrapers/section_course_linker.rb'
   # TODO: don't hardcode semester_id
-  sh "ruby app/scrapers/update_open_seats.rb #{semester}"
+  semesters.each {|semester| sh "ruby app/scrapers/update_open_seats.rb #{semester}"}
   sh 'ruby app/scrapers/bus_routes_scraper.rb'
   sh 'ruby app/scrapers/bus_schedules_scraper_small.rb'
   sh 'ruby app/scrapers/buildings.rb'

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -177,6 +177,22 @@ module Sinatra
         end
       end
 
+      def current_and_next_semesters
+        month = Time.now.month
+        year = Time.now.year
+        if month >= 1 && month <= 2
+          ["#{year}01"]
+        elsif month >= 3 && month <= 5
+          ["#{year}01", "#{year}05", "#{year}08"]
+        elsif month >= 6 && month <= 8
+          ["#{year}05", "#{year}08"]
+        elsif month >= 9 && month <= 9
+          ["#{year}08"]
+        elsif month >= 10 && month <= 12
+          ["#{year}08", "#{year}12", "#{year+1}01"]
+        end
+      end
+
       def is_course_id? string
         /^[A-Z]{4}\d{3}[A-Z]?$/.match string #if the string is of this particular format
       end


### PR DESCRIPTION
I fixed some bugs detecting the current year and added a new helper to to get all active semesters. In the future, we could make an improvement to scrape the SOC and try to see exactly what semesters are available.