### PR TITLE
Add majors endpoint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,11 @@ namespace :scrape do
   task :buildings do
     sh 'ruby app/scrapers/buildings.rb'
   end
+
+  desc "Majors scraper"
+  task :majors do
+    sh 'ruby app/scrapers/majors_scraper.rb'
+  end
 end
 
 ###### Server

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ end
 
 ###### Scraping
 desc "Scrape to fill databases (takes ~20 minutes)"
-task :scrape => ['scrape:courses', 'scrape:bus', 'scrape:buildings']
+task :scrape => ['scrape:courses', 'scrape:bus', 'scrape:buildings', 'scrape:majors']
 
 desc "Scrapes enough to run the tests"
 task :test_scrape do
@@ -47,6 +47,7 @@ task :test_scrape do
   sh 'ruby app/scrapers/bus_routes_scraper.rb'
   sh 'ruby app/scrapers/bus_schedules_scraper_small.rb'
   sh 'ruby app/scrapers/buildings.rb'
+  sh 'ruby app/scrapers/majors_scraper.rb'
 end
 
 namespace :scrape do

--- a/app/controllers/majors_controller.rb
+++ b/app/controllers/majors_controller.rb
@@ -1,0 +1,25 @@
+# Module for Majors endpoint
+
+module Sinatra
+  module UMDIO
+    module Routing
+      module Majors
+
+        def self.registered(app)
+          majors_collection = app.settings.majors_db.collection('majors')
+
+          app.before do
+            content_type 'application/json'
+          end
+
+          # Route for majors
+          app.get '/v0/majors' do
+            json majors_collection.find({},{fields: {:_id => 0}}).map { |e| e }
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/app/scrapers/majors_scraper.rb
+++ b/app/scrapers/majors_scraper.rb
@@ -1,0 +1,45 @@
+require 'open-uri'
+require 'nokogiri'
+require 'mongo'
+include Mongo
+
+#set up mongo database - code from ruby mongo driver tutorial
+host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+# announce connection and connect
+puts "Connecting to #{host}:#{port}"
+db = MongoClient.new(host, port).db('umdmajors')
+majors_coll = db.collection('majors')
+
+majors_coll.remove()
+
+url = "https://www.admissions.umd.edu/explore/majors"
+page = Nokogiri::HTML(open(url))
+major_divs = page.css("div[style='padding:0 0 3px 10px; line-height:17px;']")
+
+majors = []
+major_divs.each do |div|
+
+  # parse the name to grab the major's name and its college
+  major_parts = div.text.sub(')', '').split('(')
+  # TODO: this is currently a hacky fix to major names ending in a strange space character I couldn't remove
+  major_name = major_parts[0][0...-1]
+  major_college = major_parts[1] ? major_parts[1].strip : ''
+
+  # parse the url
+  major_url = div.css('a')[0]['href']
+
+  majors << {
+    name: major_name,
+    college: major_college,
+    url: major_url
+  }
+end
+
+majors.each do |major|
+  puts "inserting #{major[:name]}"
+
+  major[:major_id] = major[:name].upcase.gsub!(/[^0-9A-Za-z]/, '')
+  majors_coll.update({ major_id: major[:major_id] }, { "$set" => major }, { upsert: true })
+end

--- a/app/scrapers/majors_scraper.rb
+++ b/app/scrapers/majors_scraper.rb
@@ -16,15 +16,14 @@ majors_coll.remove()
 
 url = "https://www.admissions.umd.edu/explore/majors"
 page = Nokogiri::HTML(open(url))
-major_divs = page.css("div[style='padding:0 0 3px 10px; line-height:17px;']")
+major_divs = page.css("div.panel-body > div")
 
 majors = []
 major_divs.each do |div|
-
+  puts div
   # parse the name to grab the major's name and its college
   major_parts = div.text.sub(')', '').split('(')
-  # TODO: this is currently a hacky fix to major names ending in a strange space character I couldn't remove
-  major_name = major_parts[0][0...-1]
+  major_name = major_parts[0].squeeze(' ')
   major_college = major_parts[1] ? major_parts[1].strip : ''
 
   # parse the url
@@ -43,3 +42,4 @@ majors.each do |major|
   major[:major_id] = major[:name].upcase.gsub!(/[^0-9A-Za-z]/, '')
   majors_coll.update({ major_id: major[:major_id] }, { "$set" => major }, { upsert: true })
 end
+puts "Inserted #{majors.length} majors"

--- a/server.rb
+++ b/server.rb
@@ -27,6 +27,14 @@ class UMDIO < Sinatra::Base
     set :courses_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdclass')
     set :buses_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdbus')
     set :map_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmap')
+    #set :profs_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdprof')
+    set :majors_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmajors')
+  end
+
+  configure :development do
+    # TODO: fix weird namespace conflict and install better_errors
+    use BetterErrors::Middleware
+    BetterErrors.application_root = __dir__
   end
 
   # before application/request starts
@@ -55,5 +63,6 @@ class UMDIO < Sinatra::Base
   register Sinatra::UMDIO::Routing::Courses
   register Sinatra::UMDIO::Routing::Bus
   register Sinatra::UMDIO::Routing::Map
+  register Sinatra::UMDIO::Routing::Majors
   register Sinatra::UMDIO::Routing::Root
 end

--- a/server.rb
+++ b/server.rb
@@ -27,14 +27,8 @@ class UMDIO < Sinatra::Base
     set :courses_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdclass')
     set :buses_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdbus')
     set :map_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmap')
-    #set :profs_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdprof')
+    set :profs_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdprof')
     set :majors_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmajors')
-  end
-
-  configure :development do
-    # TODO: fix weird namespace conflict and install better_errors
-    use BetterErrors::Middleware
-    BetterErrors.application_root = __dir__
   end
 
   # before application/request starts

--- a/server.rb
+++ b/server.rb
@@ -27,7 +27,6 @@ class UMDIO < Sinatra::Base
     set :courses_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdclass')
     set :buses_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdbus')
     set :map_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmap')
-    set :profs_db, MongoClient.new(host, port, pool_size: 20, pool_timeout: 5).db('umdprof')
     set :majors_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmajors')
   end
 


### PR DESCRIPTION
Created a new endpoint for majors that scrapes from https://www.admissions.umd.edu/explore/majors.

Some places where I could use feedback:
- I set the ID of the majors (`majors_scraper.rb`) as the name of the major in full caps without spaces. This might be fine, but it feels kinda long. I can't think of an alternative.
- The general structure of the new endpoint (I have it as `/v0/majors`).