### PR TITLE
Move maps to postgres using Sequel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,5 @@ group :scrape do
 end
 
 gem "pg", "~> 1.1"
+
+gem "sequel", "~> 5.21"

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ task :test_scrape do
   sh "ruby app/scrapers/sections_scraper.rb #{current_semester}"
   sh 'ruby app/scrapers/bus_routes_scraper.rb'
   sh 'ruby app/scrapers/bus_schedules_scraper_small.rb'
-  sh 'ruby app/scrapers/buildings.rb'
+  sh 'ruby app/scrapers/map_scraper.rb'
   sh 'ruby app/scrapers/majors_scraper.rb'
 end
 
@@ -82,7 +82,7 @@ namespace :scrape do
 
   desc "Run building scraper"
   task :buildings do
-    sh 'ruby app/scrapers/buildings.rb'
+    sh 'ruby app/scrapers/map_scraper.rb'
   end
 
   desc "Majors scraper"

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -55,7 +55,7 @@ module Sinatra
             end
 
             # get buildings by building_id or code
-            get 'buildings/:building_id' do
+            get '/buildings/:building_id' do
               buildings = get_buildings_by_id(buildings_t, params[:building_id])
               buildings.map{|e|
                 e[:lng] = e.delete(:long)

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -1,3 +1,5 @@
+require_relative '../models/building.rb'
+
 module Sinatra
   module UMDIO
     module Routing
@@ -6,7 +8,7 @@ module Sinatra
         def self.registered(app)
           app.register Sinatra::Namespace
 
-          buildings_collection = app.settings.map_db.collection('buildings')
+          buildings_t = buildings_table(app.settings.DB)
           bad_id_message = "Check the building id in the url."
 
           app.namespace '/v1/map' do
@@ -22,22 +24,12 @@ module Sinatra
 
             # get list of all buildings with names and numbers
             get '/buildings' do
-              buildings = get_buildings(buildings_collection)
-              buildings.map{|e|
-                e['long'] = e.delete('lng')
-              }
-
-              json buildings
+              json get_buildings(buildings_t)
             end
 
             # get buildings by building_id or code
             get '/buildings/:building_id' do
-              buildings = get_buildings_by_id(buildings_collection, params[:building_id])
-              buildings.map{|e|
-                e['lon'] = e.delete('lng')
-              }
-
-              json buildings
+              json get_buildings_by_id(buildings_t, params[:building_id])
             end
           end
 
@@ -53,12 +45,24 @@ module Sinatra
 
             # get list of all buildings with names and numbers
             get '/buildings' do
-              json get_buildings(buildings_collection)
+              buildings = get_buildings(buildings_t)
+              buildings.map{|e|
+                e[:lng] = e.delete(:long)
+                e[:lng] = e[:lng].to_s
+                e[:lat] = e[:lat].to_s
+              }
+              json buildings
             end
 
             # get buildings by building_id or code
             get 'buildings/:building_id' do
-              json get_buildings_by_id(buildings_collection, params[:building_id])
+              buildings = get_buildings_by_id(buildings_t, params[:building_id])
+              buildings.map{|e|
+                e[:lng] = e.delete(:long)
+                e[:lng] = e[:lng].to_s
+                e[:lat] = e[:lat].to_s
+              }
+              json buildings
             end
           end
         end

--- a/app/helpers/map_helpers.rb
+++ b/app/helpers/map_helpers.rb
@@ -4,22 +4,19 @@ module Sinatra
   module UMDIO
     module Helpers
       def get_buildings db
-        db.find({},{fields: {:_id => 0}}).map { |e| e }
+        buildings = db.all
+        buildings.each do |e|
+          e.delete(:pid)
+        end
+
+        buildings
       end
 
       def get_buildings_by_id db, id
         building_ids = id.upcase.split(",")
         building_ids.each { |building_id| halt 400, bad_url_error(bad_id_message) unless is_building_id? building_id }
 
-        # find building ids or building codes
-        expr = {
-          '$or' => [
-            { building_id: { '$in' => building_ids} },
-            { code: { '$in' => building_ids} },
-          ]
-        }
-
-        buildings = db.find(expr, { fields: {:_id => 0} }).to_a
+        buildings = db.where(id: building_ids).or(code: building_ids)
 
         # throw 404 if empty
         if buildings == []
@@ -29,6 +26,10 @@ module Sinatra
             available_buildings: "https://api.umd.io/map/buildings",
             docs: "https://umd.io/map"
           }.to_json
+        end
+
+        buildings.each do |e|
+          e.delete(:pid)
         end
 
         buildings

--- a/app/helpers/map_helpers.rb
+++ b/app/helpers/map_helpers.rb
@@ -16,7 +16,7 @@ module Sinatra
         building_ids = id.upcase.split(",")
         building_ids.each { |building_id| halt 400, bad_url_error(bad_id_message) unless is_building_id? building_id }
 
-        buildings = db.where(id: building_ids).or(code: building_ids)
+        buildings = db.where(id: building_ids).or(code: building_ids).to_a
 
         # throw 404 if empty
         if buildings == []

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,0 +1,12 @@
+def buildings_table(db)
+    db.create_table? :buildings do
+        primary_key :pid
+        String :name
+        String :code
+        String :id
+        Float :long
+        Float :lat
+    end
+
+    db[:buildings]
+end

--- a/app/scrapers/map_scraper.rb
+++ b/app/scrapers/map_scraper.rb
@@ -7,32 +7,18 @@ require 'net/http'
 require 'mongo'
 
 require_relative 'scraper_common.rb'
+require_relative '../models/building.rb'
 include ScraperCommon
 
 prog_name = "buildings"
 
 logger = ScraperCommon::logger
-db = ScraperCommon::database 'umdmap'
-buildings_coll = db.collection('buildings')
+buildings = buildings_table(DB)
 
 url="https://gist.githubusercontent.com/McIntireEvan/34f7875ad0e302cbba8615f60460cdcb/raw/b177299262f53246c7404bbb1d2c2800dd1006c2/umd-building-gis.json"
 
-# drop buildings first
-buildings_coll.remove()
-
 array = eval open(url).read
 array.each do |e|
-  # try to add image url
-  image_url = "https://www.facilities.umd.edu/Buildings/Pictures/Medium/#{e[:number]}.jpg"
-  uri = URI(image_url)
-  status = Net::HTTP.get_response(uri)
-  unless status.kind_of? Net::HTTPNotFound
-    e[:image_url] = image_url
-  end
-
-  e[:building_id] = e[:number].upcase
-  e.delete :number
-  buildings_coll.update({building_id: e[:building_id]}, {"$set" => e}, {upsert: true})
-
+  buildings.insert(:name => e[:name], :code => e[:code], :id => e[:number].upcase, :long => e[:lng], :lat => e[:lat])
   logger.info(prog_name) {"inserted #{e[:name]}"}
 end

--- a/app/scrapers/scraper_common.rb
+++ b/app/scrapers/scraper_common.rb
@@ -1,6 +1,10 @@
 require 'logger'
+require 'sequel'
 
 module ScraperCommon
+    # TODO: Load config from memory
+    DB = Sequel.connect('postgres://postgres@postgres:5432/umdio')
+
     def logger
         @logger = Logger.new(STDOUT)
         @logger.level = Logger::INFO
@@ -11,6 +15,7 @@ module ScraperCommon
         @logger
     end
 
+    #TODO: Deprecated. Use sequel instead
     def database(table)
         host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
         port = ENV['MONGO_RUBY_DRIVER_PORT'] || Mongo::DEFAULT_PORT
@@ -19,6 +24,7 @@ module ScraperCommon
         db = Mongo::MongoClient.new(host, port, pool_size: 2, pool_timeout: 2).db(table)
     end
 
+    #TODO: Deprecated. Use sequel instead
     def postgres
         db = PG.connect(
             dbname: 'umdio',

--- a/server.rb
+++ b/server.rb
@@ -8,9 +8,14 @@ require 'sinatra/base'
 require 'sinatra/reloader'
 require 'sinatra/param'
 require 'sinatra/namespace'
-require 'mongo'
 require 'json'
+# TODO: Deprecated
+require 'mongo'
+
+# TODO: Deprecated?
 require 'pg'
+
+require 'sequel'
 
 include Mongo
 
@@ -18,12 +23,17 @@ class UMDIO < Sinatra::Base
   # Explicitly set this as the root file
   set :root, File.dirname(__FILE__)
 
+  # TODO: Load config from memory
+  DB = Sequel.connect('postgres://postgres@postgres:5432/umdio')
+
   configure do
+    # TODO: Deprecated. Use sequel instead.
     # set up mongo database - code from ruby mongo driver tutorial
     host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
     port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
     puts "Connecting to mongo on #{host}:#{port}"
 
+    # TODO: Deprecated. Use sequel instead.
     db = PG.connect(
       dbname: 'umdio',
       host: 'postgres',
@@ -38,9 +48,9 @@ class UMDIO < Sinatra::Base
 
     # we might need other databases for other endpoints, but for now this is fine, with multiple collections
     set :buses_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdbus')
-    set :map_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmap')
     set :majors_db, MongoClient.new(host,port, pool_size: 20, pool_timeout: 5).db('umdmajors')
     set :postgres, db
+    set :DB, DB
   end
 
   # before application/request starts


### PR DESCRIPTION
Rather than deal directly with writing SQL, we use the Sequel library.
We replace all mongo calls in the map endpoints with this, and clean up
the map scraper - renaming lng, as well as removing the dead image_url
code. In addition, it cleans up the typing of the response for v1
endpoints.

Resolves #120. Supersedes #121.