### PR TITLE
Fix /courses/list

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -69,7 +69,7 @@ module Sinatra
           end
 
           app.get '/v0/courses/list' do
-            json (find_courses_in_sem request.params[:semester])
+            json (find_courses_in_sem request.params['semester'])
           end
 
           # Returns section info about particular sections of a course, comma separated

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -62,7 +62,7 @@ module Sinatra
       end
 
       def find_courses_in_sem semester
-        Course.where(semester: 201908).order(Sequel.asc(:course_id)).map{|c| c.to_v0_info}
+        Course.where(semester: semester).order(Sequel.asc(:course_id)).map{|c| c.to_v0_info}
       end
 
       # gets a single course or an array or courses and halts if none are found


### PR DESCRIPTION
/v0/courses/list always returned 201908 data. This is because that was hardedcoded in, and the semester was being incorrectly passed in to the helper. Both of these issues have been resolved.

Fixes #151 