### PR TITLE
Professor and Courses v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,17 +6,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install docker-compose
-      run: |
-        curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-        chmod +x ~/docker-compose
-        sudo mv ~/docker-compose /usr/local/bin/docker-compose
-    - name: "Run everything"
-      run: |
-        docker-compose pull
-        docker-compose build
-        docker-compose up -d
-        sleep 4
-        docker exec umdio_umdio_1 bundle exec rake test_scrape
-        docker exec umdio_umdio_1 bundle exec rake
+      - uses: actions/checkout@v1
+      - name: Install docker-compose
+        run: |
+          curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+          chmod +x ~/docker-compose
+          sudo mv ~/docker-compose /usr/local/bin/docker-compose
+      - name: "Run everything"
+        run: |
+          docker-compose pull
+          docker-compose build
+          docker-compose up -d
+          sleep 10
+          docker exec umdio_umdio_1 bundle exec rake test_scrape
+          docker exec umdio_umdio_1 bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ mime.types
 
 # editor configurations
 .idea/
+
+imports/

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require_relative 'app/helpers/courses_helpers.rb'
 include Sinatra::UMDIO::Helpers
 
 ###### Scraping
-desc "Scrape to fill databases (takes ~20 minutes)"
+desc "Scrape to fill databases"
 task :scrape => ['scrape:courses', 'scrape:bus', 'scrape:buildings', 'scrape:majors']
 
 desc "Scrapes enough to run the tests"
@@ -63,8 +63,6 @@ namespace :scrape do
 end
 
 ###### Server
-
-task :setup => ['db:clean','db:up','scrape']
 
 desc "Start the web server for dev"
 task :up do

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,6 +4,153 @@ module Sinatra
     module Routing
       module Courses
         def self.registered(app)
+
+          app.register Sinatra::Namespace
+
+          app.namespace '/v1/courses' do
+            before do
+              @course_params = ['semester', 'course_id', 'credits', 'dept_id', 'grading_method', 'core', 'gen_ed', 'name']
+              @section_params = ['section_id_str', 'course_id', 'seats', 'semester']
+              @meeting_params = ['days', 'room', 'building', 'classtype', 'start_time', 'end_time']
+
+              @meeting_params.each do |p|
+                rename_param "meetings.#{p}", p
+              end
+
+              fix_sem
+
+              rename_param 'section_id', 'section_id_str'
+
+              # TODO: This could be more concise
+              if request.params['expand']
+                request.update_param('expand', request.params['expand'].to_s.downcase == 'sections')
+              end
+            end
+
+            get '/sections/:section_id' do
+              # separate into an array on commas, turn it into uppercase
+              section_ids = "#{params[:section_id]}".upcase.split(",")
+
+              section_ids.each do |section_id|
+                if not is_full_section_id? section_id
+                  halt 400, bad_url_error("Invalid section_id #{section_id}", "https://docs.umd.io/courses/")
+                end
+              end
+
+              res = (find_sections (request.params['semester']), section_ids).map {|s| s.to_v0}
+
+              json res
+            end
+
+            get '/sections' do
+              begin_paginate! $DB[:sections]
+
+              sorting = parse_sorting_params 'section_id'
+              std_params = parse_query_v0 @section_params
+              m_std_params = parse_query_v0 @meeting_params
+              res =
+                Section
+                  .where{Sequel.&(*std_params, meetings: Meeting.where(Sequel.&(*m_std_params)))}
+                  .order(*sorting)
+                  .limit(@limit)
+                  .offset((@page - 1)*@limit)
+                  .map{|s| s.to_v1}
+
+              return json [res]
+            end
+
+          get '/semesters' do
+            json list_semesters
+          end
+
+          get '/departments' do
+            json list_depts
+          end
+
+          get '/list' do
+            json (find_courses_in_sem request.params['semester']).map{|c| c.to_v1_info}
+          end
+
+          # Returns section info about particular sections of a course, comma separated
+          get '/:course_id/sections/:section_id' do
+            course_id = "#{params[:course_id]}".upcase
+
+            validate_course_ids course_id
+
+            section_numbers = "#{params[:section_id]}".upcase.split(',')
+            # TODO: validate_section_ids
+            section_numbers.each do |number|
+              if not is_section_number? number
+                halt 400,  bad_url_error("Invalid section number #{number}", "https://docs.umd.io/courses/")
+              end
+            end
+
+            section_ids = section_numbers.map { |number| "#{course_id}-#{number}" }
+
+            sections = (find_sections request.params['semester'], section_ids).map{|s| s.to_v1}
+
+            if sections.nil? or sections.empty?
+              halt 404, { error_code: 404, message: "No sections found." }.to_json
+            end
+
+            json sections
+          end
+
+          # TODO: sort??
+          # Returns section objects of a given course
+          get '/:course_id/sections' do
+            course_id = params[:course_id].upcase
+            res = find_sections_for_course_v1 request.params['semester'], course_id, true
+
+            if res.empty?
+              halt 404, {
+                error_code: 404,
+                message: "Course with course_id #{course_id} not found!",
+                available_courses: "https://api.umd.io/v0/courses",
+                docs: "https://docs.umd.io/courses/"
+              }.to_json
+            end
+
+            json res
+          end
+
+          # returns courses specified by :course_id
+          get '/:course_id' do
+            course_ids = params[:course_id].upcase.split(',')
+            courses = find_courses_v1 request.params['semester'], course_ids, request.params
+
+            json courses
+          end
+
+            # returns a paginated list of courses, with the full course objects
+            get do
+              begin_paginate! $DB[:courses]
+
+              upper_param 'dept_id'
+
+              sorting = parse_sorting_params 'course_id'
+              std_params = parse_query_v0 @course_params
+
+              res =
+                Course
+                  .where{Sequel.&(*std_params)}
+                  .order(*sorting)
+                  .limit(@limit)
+                  .offset((@page - 1)*@limit)
+                  .map{|c| c.to_v1}
+
+              end_paginate! res
+
+              res.each {|c|
+                c[:sections] = find_sections_for_course_v1 request.params['semester'], c[:course_id], request.params['expand']
+              }
+
+              return json res
+            end
+          end
+
+          # BEGIN v0
+
           app.before '/v0/courses*' do
             @course_params = ['semester', 'course_id', 'credits', 'dept_id', 'grading_method', 'core', 'gen_ed', 'name']
             @section_params = ['section_id_str', 'course_id', 'seats', 'semester']
@@ -35,7 +182,7 @@ module Sinatra
               end
             end
 
-            res = find_sections (request.params['semester']), section_ids
+            res = (find_sections (request.params['semester']), section_ids).map{|s| s.to_v0}
 
             # If we only have 1 result, we have to just return it (for compatibility)
             # TODO (v1): Fix this
@@ -65,15 +212,15 @@ module Sinatra
 
           # all of the semesters that we have
           app.get '/v0/courses/semesters' do
-            json Course.distinct(:semester).map {|c| c[:semester]}.sort
+            json list_semesters
           end
 
           app.get '/v0/courses/departments' do
-            json Course.distinct(:dept_id, :department).map {|c| {dept_id: c[:dept_id], department: c[:department]}}.sort_by! {|d| d[:dept_id]}
+            json list_depts
           end
 
           app.get '/v0/courses/list' do
-            json (find_courses_in_sem request.params['semester'])
+            json (find_courses_in_sem request.params['semester']).map{|c| c.to_v0_info}
           end
 
           # Returns section info about particular sections of a course, comma separated
@@ -92,7 +239,7 @@ module Sinatra
 
             section_ids = section_numbers.map { |number| "#{course_id}-#{number}" }
 
-            sections = find_sections request.params['semester'], section_ids
+            sections = (find_sections request.params['semester'], section_ids).map {|s| s.to_v0}
 
             if sections.nil? or sections.empty?
               halt 404, { error_code: 404, message: "No sections found." }.to_json

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -46,8 +46,8 @@ module Sinatra
               begin_paginate! $DB[:sections]
 
               sorting = parse_sorting_params 'section_id'
-              std_params = parse_query_v0 @section_params
-              m_std_params = parse_query_v0 @meeting_params
+              std_params = parse_query_v1 @section_params
+              m_std_params = parse_query_v1 @meeting_params
               res =
                 Section
                   .where{Sequel.&(*std_params, meetings: Meeting.where(Sequel.&(*m_std_params)))}
@@ -129,7 +129,7 @@ module Sinatra
               upper_param 'dept_id'
 
               sorting = parse_sorting_params 'course_id'
-              std_params = parse_query_v0 @course_params
+              std_params = parse_query_v1 @course_params
 
               res =
                 Course

--- a/app/controllers/professors_controller.rb
+++ b/app/controllers/professors_controller.rb
@@ -8,16 +8,15 @@ module Sinatra
           app.register Sinatra::Namespace
 
           app.namespace '/v1/professors' do
-            app.before '*' do
+            before '*' do
               @special_params = ['sort', 'per_page', 'page']
-              @section_params = ['semester', 'course_id', 'dept_id']
+              @section_params = ['semester', 'course_id']
               @prof_params = ['name']
 
+              rename_param 'course', 'course_id'
               rename_param 'courses', 'course_id'
-              rename_param 'departments', 'dept_id'
 
               upper_param 'course_id'
-              upper_param 'dept_id'
             end
 
             get do

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -3,6 +3,20 @@ module Sinatra
   module UMDIO
     module Helpers
 
+      # Generic course helpers
+
+      def list_semesters
+        Course.distinct(:semester).map {|c| c[:semester]}.sort
+      end
+
+      def list_depts
+        Course.distinct(:dept_id, :department).map {|c| {dept_id: c[:dept_id], department: c[:department]}}.sort_by! {|d| d[:dept_id]}
+      end
+
+      def find_courses_in_sem semester
+        Course.where(semester: semester).order(Sequel.asc(:course_id))
+      end
+
       # generalize logic for checking if semester param valid
       def check_semester app, semester
         # check for semester formatting
@@ -17,8 +31,7 @@ module Sinatra
 
       # helper method for printing json-formatted sections based on a sections collection and a list of section_ids
       def find_sections semester, section_ids
-        # Turn section_ids into string
-        res = Section.where(semester: semester, section_id_str: section_ids).map{|s| s.to_v0}
+        res = Section.where(semester: semester, section_id_str: section_ids)
 
         if !res
           halt 404, {
@@ -31,6 +44,7 @@ module Sinatra
 
         return res
       end
+
 
       def validate_section_ids section_ids, do_halt=true
         section_ids = [section_ids] if section_ids.is_a?(String)
@@ -59,8 +73,39 @@ module Sinatra
         return true
       end
 
-      def find_courses_in_sem semester
-        Course.where(semester: semester).order(Sequel.asc(:course_id)).map{|c| c.to_v0_info}
+      # gets a single course or an array or courses and halts if none are found
+      # @return: Array of courses
+      def find_courses_v1 semester, course_ids, params
+        course_ids = [course_ids] if course_ids.is_a?(String)
+
+        validate_course_ids course_ids
+
+        courses = Course.where(semester: semester, course_id: course_ids).map{|c| c.to_v1}
+        # check if found
+        if courses.empty?
+          s = course_ids.length > 1 ? 's' : ''
+          halt 404, {
+            error_code: 404,
+            message: "Course#{s} with course_id#{s} #{course_ids.join(',')} not found!",
+            available_courses: "https://api.umd.io/v0/courses",
+            docs: "https://docs.umd.io/courses/"
+          }.to_json
+        end
+
+        courses.each{|c| c['sections'] = find_sections_for_course_v1 semester, c[:course_id], params['expand']}
+        courses
+      end
+
+      def find_sections_for_course_v1 semester, course_id, expand
+        sections = []
+
+        if expand
+          sections = Section.where(semester: semester, course_id: course_id).map{|s| s.to_v1}
+        else
+          sections = Section.where(semester: semester, course_id: course_id).map{|s| s[:section_id_str]}
+        end
+
+        return sections
       end
 
       # gets a single course or an array or courses and halts if none are found

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -76,10 +76,10 @@ module UMDIO
     end
 
     def fix_sem
-      if !request.params[:semester]
+      if !request.params['semester']
         request.update_param('semester', current_semester)
       end
-      check_semester app, request.params['semester']
+      check_semester app, params['semester']
     end
 
     def rename_param from, to

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -76,10 +76,10 @@ module UMDIO
     end
 
     def fix_sem
-      if !request.params['semester']
+      if !params['semester']
         request.update_param('semester', current_semester)
       end
-      check_semester app, params['semester']
+      check_semester app, request.params['semester']
     end
 
     def rename_param from, to

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -89,6 +89,12 @@ module UMDIO
       end
     end
 
+    def upper_param name
+      if request.params[name]
+        request.update_param(name, request.params[name].upcase)
+      end
+    end
+
     # Turn request.params into a reasonable format
     def standardize_params
       std_params = {}

--- a/app/models/courses.rb
+++ b/app/models/courses.rb
@@ -130,4 +130,18 @@ class Professor < Sequel::Model
             department: depts.uniq
         }
     end
+
+    def to_v1
+        ss = sections.map{|s| s.to_v0}
+        taught = []
+
+        ss.each {|s|
+            taught << {course_id: s[:course], semester: s[:semester]}
+        }
+
+        {
+            name: name,
+            taught: taught.uniq
+        }
+    end
 end

--- a/app/models/courses.rb
+++ b/app/models/courses.rb
@@ -49,6 +49,30 @@ end
 $DB.create_join_table?(:professor_id=>:professors, :section_id=>:sections)
 
 class Course < Sequel::Model
+    def to_v1
+        {
+            course_id: course_id,
+            semester: semester.to_s,
+            name: name,
+            dept_id: dept_id,
+            department: department,
+            credits: credits,
+            description: description,
+            grading_method: grading_method,
+            gen_ed: gen_ed,
+            core: core,
+            relationships: relationships
+        }
+    end
+
+    def to_v1_info
+        {
+            course_id: course_id,
+            dept_id: dept_id,
+            name: name
+        }
+    end
+
     def to_v0
         {
             course_id: course_id,
@@ -75,6 +99,17 @@ class Course < Sequel::Model
 end
 
 class Meeting < Sequel::Model
+    def to_v1
+        {
+            days: days,
+            room: room,
+            building: building,
+            classtype: classtype,
+            start_time: start_time,
+            end_time: end_time
+        }
+    end
+
     def to_v0
         {
             days: days,
@@ -90,6 +125,22 @@ end
 class Section < Sequel::Model
     one_to_many :meetings, key: :section_key
     many_to_many :professors
+
+    def to_v1
+        profs = professors.map {|p| p[:name]}
+
+        {
+            course: course_id,
+            section_id: section_id_str,
+            semester: semester.to_s,
+            number: number,
+            seats: seats,
+            meetings: meetings.map {|m| m.to_v1},
+            open_seats: open_seats,
+            waitlist: waitlist,
+            instructors: profs
+        }
+    end
 
     def to_v0
         profs = professors.map {|p| p[:name]}

--- a/app/models/courses.rb
+++ b/app/models/courses.rb
@@ -1,3 +1,4 @@
+$DB.drop_table? :courses
 $DB.create_table? :courses do
     primary_key :pid
     String :course_id
@@ -8,7 +9,7 @@ $DB.create_table? :courses do
     String :credits
     String :description
     column :grading_method, :jsonb
-    column :gen_ed, :jsonb
+    String :gen_ed
     column :core, :jsonb
     column :relationships, :jsonb
     unique [:course_id, :semester]

--- a/app/models/courses.rb
+++ b/app/models/courses.rb
@@ -1,4 +1,3 @@
-$DB.drop_table? :courses
 $DB.create_table? :courses do
     primary_key :pid
     String :course_id
@@ -51,6 +50,16 @@ $DB.create_join_table?(:professor_id=>:professors, :section_id=>:sections)
 
 class Course < Sequel::Model
     def to_v1
+        ge = gen_ed.gsub(/\s/, '').split('or').map do |s|
+            s.split(',').map do |s2|
+                ret = s2
+                if m = s2.match(/^(.{4})\(iftakenwith(.*)\)$/)
+                    ret = "#{m[1]}|#{m[2]}"
+                end
+                ret
+            end
+        end
+
         {
             course_id: course_id,
             semester: semester.to_s,
@@ -60,7 +69,7 @@ class Course < Sequel::Model
             credits: credits,
             description: description,
             grading_method: grading_method,
-            gen_ed: gen_ed,
+            gen_ed: ge,
             core: core,
             relationships: relationships
         }
@@ -84,7 +93,7 @@ class Course < Sequel::Model
             credits: credits,
             description: description,
             grading_method: grading_method,
-            gen_ed: gen_ed,
+            gen_ed: gen_ed.gsub(/\s/, '').gsub("iftakenwith","fkwh").split(','),
             core: core,
             relationships: relationships
         }

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -147,7 +147,7 @@ dep_urls.each do |url|
       credits: course.css('span.course-min-credits').first.content,
       grading_method: course.at_css('span.grading-method abbr') ? course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
       core: utf_safe(course.css('div.core-codes-group').text).gsub(/\s/, '').delete('CORE:').split(','),
-      gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:').split(','),
+      gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:'),
       description: description,
       relationships: relationships
     }
@@ -163,7 +163,7 @@ dep_urls.each do |url|
       :credits => course[:credits],
       :description => course[:description],
       :grading_method => Sequel.pg_jsonb_wrap(course[:grading_method]),
-      :gen_ed => Sequel.pg_jsonb_wrap(course[:gen_ed]),
+      :gen_ed => course[:gen_ed],
       :core => Sequel.pg_jsonb_wrap(course[:core]),
       :relationships => Sequel.pg_jsonb_wrap(course[:relationships])
     )

--- a/app/scrapers/courses_scraper.rb
+++ b/app/scrapers/courses_scraper.rb
@@ -147,7 +147,7 @@ dep_urls.each do |url|
       credits: course.css('span.course-min-credits').first.content,
       grading_method: course.at_css('span.grading-method abbr') ? course.at_css('span.grading-method abbr').attr('title').split(', ') : [],
       core: utf_safe(course.css('div.core-codes-group').text).gsub(/\s/, '').delete('CORE:').split(','),
-      gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).gsub(/\s/, '').delete('General Education:'),
+      gen_ed: utf_safe(course.css('div.gen-ed-codes-group').text).delete('General Education:'),
       description: description,
       relationships: relationships
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36,11 +36,206 @@ tags:
     description: Data about the various majors offered on campus.
   - name: professors
     description: Data about professors and courses they teach
+  - name: courses
+    description: Course data from Testudo
 paths:
-  /v1/professors:
+  /courses:
     get:
       tags:
-        - proessors
+        - courses
+      summary: List courses
+      description: Returns paginated list of courses
+      operationId: getCourses
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Course"
+  /courses/list:
+    get:
+      tags:
+        - courses
+      summary: List courses
+      description: Returns list of all minimized courses
+      operationId: getCourses
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Course"
+  /courses/sections:
+    get:
+      tags:
+        - courses
+      summary: List sections
+      description: Returns paginated list of sections
+      operationId: getSections
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Section"
+  /courses/sections/{section_ids}:
+    get:
+      tags:
+        - courses
+      summary: List sections
+      description: Returns paginated list of sections
+      operationId: getSections
+      parameters:
+        - in: path
+          name: section_ids
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: One or more comma separated section ids
+          explode: true
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Section"
+  /courses/{course_ids}:
+    get:
+      tags:
+        - courses
+      summary: View course
+      description: Returns info about one or more courses
+      operationId: getCoursesById
+      parameters:
+        - in: path
+          name: course_ids
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: One or more comma separated course ids
+          explode: true
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Course"
+  /courses/{course_ids}/sections:
+    get:
+      tags:
+        - courses
+      summary: View course
+      description: Returns info about one or more courses
+      operationId: getCourseSectionsById
+      parameters:
+        - in: path
+          name: course_ids
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: One or more comma separated course ids
+          explode: true
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Section"
+  /courses/{course_ids}/sections/{section_ids}:
+    get:
+      tags:
+        - courses
+      summary: View course
+      description: Returns info about one or more courses
+      operationId: getCourseSectionsById
+      parameters:
+        - in: path
+          name: course_ids
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: One or more comma separated course ids
+          explode: true
+        - in: path
+          name: section_ids
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+          description: One or more comma separated section ids
+          explode: true
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Section"
+  /courses/semesters:
+    get:
+      tags:
+        - courses
+      summary: List semesters
+      description: Returns list of all available semesters
+      operationId: getSemesters
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /courses/departments:
+    get:
+      tags:
+        - courses
+      summary: List departments
+      description: Returns list of all available departments
+      operationId: getDepartments
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /professors:
+    get:
+      tags:
+        - professors
       summary: List professors
       description: Returns list of all professors
       operationId: getProfessors
@@ -53,7 +248,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Professor"
-  /v1/majors/list:
+  /majors/list:
     get:
       tags:
         - majors
@@ -69,7 +264,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Major"
-  /v1/map/buildings:
+  /map/buildings:
     get:
       tags:
         - map
@@ -85,7 +280,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Building"
-  /v1/map/buildings/{building_id}:
+  /map/buildings/{building_id}:
     get:
       tags:
         - map
@@ -136,6 +331,108 @@ paths:
 
 components:
   schemas:
+    Course:
+      type: object
+      description: Represents a course on Testudo
+      properties:
+        course_id:
+          type: string
+        semester:
+          type: string
+        name:
+          type: string
+        dept_id:
+          type: string
+        department:
+          type: string
+        credits:
+          type: string
+        description:
+          type: string
+        grading_method:
+          type: array
+          items:
+            type: string
+        gen_ed:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+        core:
+          type: array
+          items:
+            type: string
+        relationships:
+          type: object
+          properties:
+            coreqs:
+              type: string
+              nullable: true
+            prereqs:
+              type: string
+              nullable: true
+            formerly:
+              type: string
+              nullable: true
+            restrictions:
+              type: string
+              nullable: true
+            additional_info:
+              type: string
+              nullable: true
+            also_offered_as:
+              type: string
+              nullable: true
+            credit_granted_for:
+              type: string
+              nullable: true
+        sections:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - $ref: "#/components/schemas/Section"
+    Section:
+      type: object
+      properties:
+        course:
+          type: string
+        section_id:
+          type: string
+        semester:
+          type: string
+        number:
+          type: string
+        seats:
+          type: string
+        meetings:
+          type: array
+          items:
+            $ref: "#/components/schemas/Meeting"
+        open_seats:
+          type: string
+        waitlist:
+          type: string
+        instructors:
+          type: array
+          items:
+            type: string
+    Meeting:
+      type: object
+      properties:
+        days:
+          type: string
+        room:
+          type: string
+        building:
+          type: string
+        classtype:
+          type: string
+        start_time:
+          type: string
+        end_time:
+          type: string
     Professor:
       type: object
       description: Represents a professor

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,14 +34,32 @@ tags:
     description: Data about things on campus, such as buildings, dining halls, and other facilities.
   - name: majors
     description: Data about the various majors offered on campus.
+  - name: professors
+    description: Data about professors and courses they teach
 paths:
+  /v1/professors:
+    get:
+      tags:
+        - proessors
+      summary: List professors
+      description: Returns list of all professors
+      operationId: getProfessors
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Professor"
   /v1/majors/list:
     get:
       tags:
         - majors
       summary: List majors
       description: Get a list of all majors
-      operationId: findMajors
+      operationId: getMajors
       responses:
         "200":
           description: Successful Operation
@@ -57,7 +75,7 @@ paths:
         - map
       summary: List buildings
       description: Get a list of the available buildings.
-      operationId: findBuildings
+      operationId: getBuildings
       responses:
         "200":
           description: Successful Operation
@@ -75,7 +93,7 @@ paths:
       description: >-
         Get location data about one or more buildings. Comma separated building
         numbers are the parameters.
-      operationId: findBuildingById
+      operationId: getBuildingById
       parameters:
         - in: path
           name: building_id
@@ -118,6 +136,25 @@ paths:
 
 components:
   schemas:
+    Professor:
+      type: object
+      description: Represents a professor
+      properties:
+        name:
+          type: string
+          description: Professor's name on Testudo
+          example: ""
+        taught:
+          type: array
+          items:
+            type: object
+            properties:
+              semester:
+                type: integer
+                example: 202001
+              course:
+                type: string
+                example: ""
     Major:
       type: object
       description: Represents a major


### PR DESCRIPTION
* Updated internal representation of professors. Long story short, they're stored in a relationwal with respect to sections
* Updated internal representation of gen ed codes. Now, we store the raw string from testudo, and transform it based on the version.
* Updated formatting of gen ed codes for v1. (Resolves #33 , Resolves #59 ). In short, we use an array of arrays. The outer array is an "OR", the inners are "AND". Cases like DSNL(If taken with XXXXYYY) are now represented as DSNL|XXXXYYYY
* Updated json dump importer to account for new format
* Create v1 versions of all course endpoints, update helpers some
* Added some docs
* Add v1 querying for courses (Resolved #127 )