### PR TITLE
fix loading local docs failing due to CORS

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -88,6 +88,7 @@ module Sinatra
           end
 
           app.get '/v1/spec.yaml' do
+            headers['Access-Control-Allow-Origin'] = '*'
             File.read('openapi.yaml')
           end
 


### PR DESCRIPTION
we host our (local) docs on http://0.0.0.0:8080/, which makes a request to http://localhost:3000/v1/spec.yaml. Problem is, different ports are considered different origins when on localhost, so this fails since we haven't set CORS headers on our umdio server. This pr adds those headers.

Ideally, we would only set CORS headers for localhost, but I am a little shocked to find a) there is no way to only whitelist `http://localhost:*` and b) there is no (easy) way to whitelist multiple urls, since we want this to be accessible via both `http://0.0.0.0:8080/` and `http://localhost:8080/`, which are different servers for CORS purposes. So I added it for all origins.

I don't think there's any harm in enabling CORS for this file for all sites (who's going to want to request it anyway? it's public on github), but I'm not 100% confident on the security ramifications of CORS, so feel free to correct me there.

