### PR TITLE
fix v0 docs link and newlines

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,9 +15,11 @@ info:
     We're now in version 1! We might add new endpoints or more data to existing responses,
     but we won't remove anything without a major version change.
 
-    If you're looking for the v0 docs, you can find them at https://v0-docs.umd.io.
+
+    If you're looking for the v0 docs, you can find them at https://docs.umd.io/.
     Please note that v0 is deprecated. It will continue to be supported until at least 2021,
     but will get no further feature updates, and will eventually be discontinued.
+
 
     We are actively looking for contributors! Tweet, email, or otherwise get in
     touch with us.


### PR DESCRIPTION
old link 404s. Also uses three newlines instead of 2 because apparently that's what openapi requires to actually display a new paragraph.