### PR TITLE
Actually use a production environment in our production setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Gemfile.lock
 bower_components
 tmp
 /bin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,12 +6,7 @@ ENV APP_HOME /umdio/
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
-RUN bundle config set without 'development,test' && \
-    bundle config set frozen 'true'
-
-
 ADD Gemfile* $APP_HOME
-# RUN bundle install --frozen --without development,test
 RUN bundle install
 
 ADD . $APP_HOME

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'sinatra-param', '~> 1.6'
 group :development do
   gem 'better_errors'
   gem 'rspec'
-  gem 'shotgun'
+  gem 'rerun', '~> 0.13.1'
   gem 'solargraph'
   gem 'debase'
   gem 'ruby-debug-ide', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,181 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    backport (1.1.2)
+    backports (3.21.0)
+    benchmark (0.1.1)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    codecov (0.5.2)
+      simplecov (>= 0.15, < 0.22)
+    coderay (1.1.3)
+    debase (0.2.4.1)
+      debase-ruby_core_source (>= 0.10.2)
+    debase-ruby_core_source (0.10.12)
+    diff-lcs (1.4.4)
+    docile (1.3.5)
+    dotenv (2.7.6)
+    e2mmap (0.1.0)
+    erubi (1.10.0)
+    ffi (1.15.0)
+    jaro_winkler (1.5.4)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mini_portile2 (2.5.1)
+    multi_json (1.15.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.7)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-linux)
+      racc (~> 1.4)
+    parallel (1.20.1)
+    parallel_tests (3.7.0)
+      parallel
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    pg (1.2.3)
+    puma (4.3.7)
+      nio4r (~> 2.0)
+    racc (1.5.2)
+    rack (2.2.3)
+    rack-mini-profiler (2.3.2)
+      rack (>= 1.2.0)
+    rack-protection (2.0.8.1)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    regexp_parser (2.1.1)
+    rerun (0.13.1)
+      listen (~> 3.0)
+    reverse_markdown (2.0.0)
+      nokogiri
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.13.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    rubocop-sequel (0.2.0)
+      rubocop (~> 1.0)
+    ruby-debug-ide (0.7.2)
+      rake (>= 0.8.1)
+    ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.4)
+    sequel (5.44.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.8.1)
+      backports (>= 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.8.1)
+      sinatra (= 2.0.8.1)
+      tilt (~> 2.0)
+    sinatra-cross_origin (0.4.0)
+    sinatra-param (1.6.0)
+      sinatra (>= 1.3)
+    solargraph (0.40.4)
+      backport (~> 1.1)
+      benchmark
+      bundler (>= 1.17.2)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      reverse_markdown (>= 1.0.5, < 3)
+      rubocop (>= 0.52)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+    thor (1.1.0)
+    tilt (2.0.10)
+    unicode-display_width (2.0.0)
+    yard (0.9.26)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  better_errors
+  codecov
+  debase
+  dotenv
+  nokogiri
+  parallel_tests
+  pg (~> 1.2.3)
+  puma (~> 4.3)
+  rack-mini-profiler
+  rack-test
+  rake
+  rerun (~> 0.13.1)
+  rspec
+  rubocop (~> 1.12)
+  rubocop-rake
+  rubocop-rspec
+  rubocop-sequel
+  ruby-debug-ide
+  ruby-progressbar
+  sequel (~> 5.31)
+  simplecov
+  sinatra (~> 2.0.8.1)
+  sinatra-contrib
+  sinatra-cross_origin (~> 0.4.0)
+  sinatra-param (~> 1.6)
+  solargraph
+
+RUBY VERSION
+   ruby 2.7.2p137
+
+BUNDLED WITH
+   2.2.16

--- a/Rakefile
+++ b/Rakefile
@@ -200,13 +200,14 @@ end
 #################################### Server ####################################
 desc 'Start the web server for dev'
 task :up do
-  system 'shotgun -p 3000 -o 0.0.0.0'
+  # system 'shotgun -p 3000 -o 0.0.0.0'
+  system 'rerun --background -- rackup --port 3000 -o 0.0.0.0 config.ru'
 end
 task server: :up
 
 desc 'Start the web server for prod'
 task :prod do
-  system 'puma -p 3000'
+  system 'puma -p 3000 config.ru'
 end
 
 desc 'Sinatra console'

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,6 +3,7 @@ services:
   # PostgreSQL Database
   postgres:
     image: postgres
+    container_name: postgres_dev
     environment:
       - POSTGRES_DB=umdio
     volumes:
@@ -22,7 +23,10 @@ services:
 
   # UMD.io Server
   umdio:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: umdio_dev
     volumes:
       - ./:/umdio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,14 @@ services:
   # UMD.io Server
   umdio:
     build: .
+    environment:
+      APP_ENV: production
+      RACK_ENV: production
     volumes:
       - ./:/umdio
     ports:
       - 3000:3000
     depends_on:
       - postgres
-    command: bundle exec rake up
+    command: bundle exec rake prod
     restart: always

--- a/server.rb
+++ b/server.rb
@@ -25,6 +25,14 @@ class UMDIO < Sinatra::Base
     enable :cross_origin
   end
 
+  configure :development do
+    use BetterErrors::Middleware
+    BetterErrors.application_root = __dir__
+    BetterErrors::Middleware.allow_ip! '172.0.0.0/8'
+    BetterErrors::Middleware.allow_ip! '192.168.0.0/16'
+    # BetterErrors::Middleware.allow_ip! '172.28.0.1'
+  end
+
   # before application/request starts
   before do
     content_type 'application/json'


### PR DESCRIPTION
Our production setup was actually running in 'development' - sure, it's not using `shotgun`, but all development dependencies were still being installed, and both `rack` and `puma` were configured for development. This PR fixes this.

Additionally, `better-errors` was not working because of our use of docker. By default, it is configured to only return `better-errors` error pages when requests are from `localhost`. This is now fixed, and errors in development should display code snippets from each part of an error's stacktrace.