### PR TITLE
Fixed bug in bus route tests

### DIFF
--- a/tests/spec_helper.rb
+++ b/tests/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   # mute noise for parallel tests
   config.silence_filter_announcements = true if ENV['TEST_ENV_NUMBER']
 
+  # https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples
   shared_examples_for 'good status' do |url|
     before { get url }
     it 'has a good response' do

--- a/tests/v0/buses_spec.rb
+++ b/tests/v0/buses_spec.rb
@@ -1,31 +1,95 @@
 require_relative '../spec_helper'
+require 'sequel'
+
+# @type [Sequel::Database]
+$DB = Sequel.connect('postgres://postgres@postgres:5432/umdio')
+$DB.extension :pg_array, :pg_json, :pagination
+Sequel.extension :pg_json_ops
+
+# Matches a float encoded as a string
+FLOAT_REGEX = /^[+-]?(\d*[.])?\d+$/.freeze
 
 describe 'Bus Endpoint v0' do
   url = '/v0/bus'
   bad_route_message = "umd.io doesn't know the bus route in your url. Full list at https://api.umd.io/v0/bus/routes"
   bad_stop_message = "umd.io doesn't know the stop in your url. Full list at https://api.umd.io/v0/bus/routes"
+  route = $DB[:routes].select(:route_id, :stops).first
+
+  raise 'Route query returned no data. Make sure the query is conformant to the routes schema.' if route.nil? || route.empty?
+
+  # @type [Integer]
+  route_id = route[:route_id]
+  # @type [String]
+  first_stop = route[:stops][0]
+
+  raise "Bad route shape, got id '#{route_id}' and stop '#{first_stop}'" unless !route_id&.empty? && !first_stop&.empty?
 
   describe 'get list of routes' do
     it_has_behavior 'good status', url + '/routes'
   end
 
   describe 'get individual route data' do
-    it_has_behavior 'good status', url + '/routes/118'
+    it_has_behavior 'good status', url + "/routes/#{route_id}"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE', bad_route_message
   end
 
   describe 'get route schedules' do
-    it_has_behavior 'good status', url + '/routes/118/schedules'
+    it_has_behavior 'good status', url + "/routes/#{route_id}/schedules"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE/schedules', bad_route_message
   end
 
   describe 'get route predicted arrivals' do
-    it_has_behavior 'good status', url + '/routes/115/arrivals/stamsu_d'
-    it_has_behavior 'bad status', url + '/routes/NOTAROUTE/arrivals/stamsu_d', bad_route_message
+    it_has_behavior 'good status', url + "/routes/#{route_id}/arrivals/#{first_stop}"
+    it_has_behavior 'bad status', url + "/routes/NOTAROUTE/arrivals/#{first_stop}", bad_route_message
+    it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals/NOTASTOP", bad_route_message
   end
 
   describe 'get locations of buses' do
-    it_has_behavior 'good status', url + '/routes/115/locations'
+    it_has_behavior 'good status', url + "/routes/#{route_id}/locations"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE/locations', bad_route_message
+  end
+
+  describe 'get list of bus stops' do
+    let(:res) { JSON.parse(last_response.body) }
+
+    include_examples 'good status', url + '/stops'
+
+    it 'returns a non-empty list' do
+      expect(res).to be_an Array
+      expect(res).to_not be_empty
+    end
+
+    it 'stop data matches the expected shape' do
+      expect(res).to all include(
+        'stop_id' => (a_kind_of String),
+        'title' => (a_kind_of String)
+      )
+    end
+  end
+
+  describe 'get an individual bus stop' do
+    context 'when the bus stop exists' do
+      let(:res) { JSON.parse(last_response.body) }
+
+      include_examples 'good status', url + '/stops/regdrgar_d'
+
+      it 'returns a hash' do
+        pending 'Stop object is wrapped in a list for some reason'
+        expect(res).to be_a Hash
+      end
+
+      it 'returns a stop object' do
+        expect(res).to include(
+          'stop_id' => 'regdrgar_d',
+          'title' => 'Regents Drive Garage',
+          'lat' => (a_kind_of String).and(match FLOAT_REGEX),
+          'lon' => (a_kind_of String).and(match FLOAT_REGEX)
+        )
+      end
+    end
+
+    context 'when the bus stop does not exist or the id is malformed' do
+      it_has_behavior 'bad status', url + '/stops/NOTASTOP'
+    end
   end
 end

--- a/tests/v1/buses_spec.rb
+++ b/tests/v1/buses_spec.rb
@@ -65,11 +65,17 @@ describe 'Bus Endpoint v1', :endpoint, :buses do
   end
 
   describe 'get /routes/:route_id/arrivals/:stop_id' do
-    # TODO: Change to good
-    it_has_behavior 'bad status', url + "/routes/#{route_id}/#{first_stop}"
-    it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals"
-    it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals/NOTASTOP"
-    it_has_behavior 'bad status', url + '/routes/NOTAROUTE/arrivals/NOTASTOP'
+    context 'when both the route and stop are valid' do
+      # FIXME(don): endpoint is broken, returns 'Bus Service Unavailable'
+      # it_has_behavior 'good status', url + "/routes/#{route_id}/arrivals/#{first_stop}"
+    end
+
+    context 'when either the route and/or stop are malformed or invalid' do
+      it_has_behavior 'bad status', url + "/routes/#{route_id}/#{first_stop}"
+      it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals"
+      it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals/NOTASTOP"
+      it_has_behavior 'bad status', url + '/routes/NOTAROUTE/arrivals/NOTASTOP'
+    end
   end
 
   describe 'get /routes/:route_id/locations' do

--- a/tests/v1/buses_spec.rb
+++ b/tests/v1/buses_spec.rb
@@ -1,8 +1,29 @@
 require_relative '../spec_helper'
+require 'sequel'
 
+# @type [Sequel::Database]
+$DB = Sequel.connect('postgres://postgres@postgres:5432/umdio')
+$DB.extension :pg_array, :pg_json, :pagination
+Sequel.extension :pg_json_ops
 
 describe 'Bus Endpoint v1', :endpoint, :buses do
   include BusMatchers
+
+  url = '/v1/bus'
+  bad_route_message = "umd.io doesn't know the bus route in your url. Full list at https://api.umd.io/v1/bus/routes"
+  bad_stop_message = "umd.io doesn't know the stop in your url. Full list at https://api.umd.io/v1/bus/routes"
+  # NOTE(don): cannot be done in before all block, needed in describe call and
+  # before_all is run after describe call but before it call
+  route = $DB[:routes].select(:route_id, :stops).first
+
+  raise 'Route query returned no data. Make sure the query is conformant to the routes schema.' if route.nil? || route.empty?
+
+  # @type [Integer]
+  route_id = route[:route_id]
+  # @type [String]
+  first_stop = route[:stops][0]
+
+  raise "Bad route shape, got id '#{route_id}' and stop '#{first_stop}'" unless !route_id&.empty? && !first_stop&.empty?
 
   # Bus matchers and examples
 
@@ -25,37 +46,34 @@ describe 'Bus Endpoint v1', :endpoint, :buses do
     end
   end
 
-  url = '/v1/bus'
-  bad_route_message = "umd.io doesn't know the bus route in your url. Full list at https://api.umd.io/v1/bus/routes"
-  bad_stop_message = "umd.io doesn't know the stop in your url. Full list at https://api.umd.io/v1/bus/routes"
-
   describe 'get /bus' do
     it_has_behavior 'good status', url
   end
+
   describe 'get /routes' do
     it_has_behavior 'successful bus route list payload', url + '/routes'
   end
 
   describe 'get /routes/:route_id' do
-    it_has_behavior 'good status', url + '/routes/118'
+    it_has_behavior 'good status', url + "/routes/#{route_id}"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE', bad_route_message
   end
 
   describe 'get /routes/:route_id/schedules' do
-    it_has_behavior 'good status', url + '/routes/118/schedules'
+    it_has_behavior 'good status', url + "/routes/#{route_id}/schedules"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE/schedules', bad_route_message
   end
 
   describe 'get /routes/:route_id/arrivals/:stop_id' do
     # TODO: Change to good
-    it_has_behavior 'bad status', url + '/routes/118/stamsu_d'
-    it_has_behavior 'bad status', url + '/routes/118/arrivals'
-    it_has_behavior 'bad status', url + '/routes/118/arrivals/NOTASTOP'
+    it_has_behavior 'bad status', url + "/routes/#{route_id}/#{first_stop}"
+    it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals"
+    it_has_behavior 'bad status', url + "/routes/#{route_id}/arrivals/NOTASTOP"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE/arrivals/NOTASTOP'
   end
 
   describe 'get /routes/:route_id/locations' do
-    it_has_behavior 'error status', url + '/routes/118/locations'
+    it_has_behavior 'error status', url + "/routes/#{route_id}/locations"
     it_has_behavior 'bad status', url + '/routes/NOTAROUTE/locations'
   end
 
@@ -64,11 +82,46 @@ describe 'Bus Endpoint v1', :endpoint, :buses do
   end
 
   describe 'get /stops' do
-    it_has_behavior 'good status', url + '/stops'
+    let(:res) { JSON.parse(last_response.body) }
+
+    include_examples 'good status', url + '/stops'
+
+    it 'returns a non-empty list' do
+      expect(res).to be_an Array
+      expect(res).to_not be_empty
+    end
+
+    it 'stop data matches the expected shape' do
+      expect(res).to all include(
+        'stop_id' => (a_kind_of String),
+        'title' => (a_kind_of String)
+      )
+    end
   end
 
   describe 'get /stops/:stop_id' do
-    it_has_behavior 'good status', url + '/stops/stamsu_d'
-    it_has_behavior 'bad status', url + '/stops/NOTASTOP'
+    context 'when a stop for stop_id exists' do
+      let(:res) { JSON.parse(last_response.body) }
+
+      include_examples 'good status', url + '/stops/regdrgar_d'
+
+      it 'returns a hash' do
+        pending 'Stop object is wrapped in a list for some reason'
+        expect(res).to be_a hash
+      end
+
+      it 'returns a stop object' do
+        expect(res).to include(
+          'stop_id' => 'regdrgar_d',
+          'title' => 'Regents Drive Garage',
+          'lat' => (a_kind_of Float),
+          'long' => (a_kind_of Float)
+        )
+      end
+    end
+
+    context 'when stop_id is malformed or no stop for it exists' do
+      it_has_behavior 'bad status', url + '/stops/NOTASTOP'
+    end
   end
 end


### PR DESCRIPTION
Fixes problem found in #221.

- fix: Tests relied on route 118, which is not active during the summer and
  therefore not present. Now, the first route in the routes table is
  queried directy from the database before tests are run and used
  in each test case.
- test: Added missing test cases for /stops, /stops/:stop_id in v0 suite
- test: Added result shape assertions to a couple of test cases
- todo: extract database connection logic from server.rb,
  scraper_common.rb, and both buses_spec.rb into separate file.