### PR TITLE
pin postgres to v13

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres
+    image: postgres:13
     environment:
       - POSTGRES_DB=umdio
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres
+    image: postgres:13
     environment:
       - POSTGRES_DB=umdio
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
the automatic upgrade to v14 (released in september 2021) caused issues with my setup as dbs created with v13 are incompatible with v14. We really should be pinning postgres to some version in the first place.