### PR TITLE
update docs url for v1 routes

### DIFF
--- a/app/controllers/bus_controller.rb
+++ b/app/controllers/bus_controller.rb
@@ -9,14 +9,14 @@ module Sinatra
             # this should probably be a more specific error message where we error out!
             bad_route_message = "umd.io doesn't know the bus route in your url. Full list at https://api.umd.io/v1/bus/routes"
             bad_stop_message = "umd.io doesn't know the stop in your url. Full list at https://api.umd.io/v1/bus/routes"
-            bus_docs_url = 'https://docs.umd.io/#tags/bus'
+            bus_docs_url = 'https://beta.umd.io/#tags/bus'
             api_root = 'https://retro.umoiq.com/service/publicJSONFeed?a=umd'
             require 'net/http'
 
             get do
               resp = {
                 message: 'This is the bus endpoint.',
-                docs: 'https://docs.umd.io/#tags/bus/'
+                docs: 'https://beta.umd.io/#tags/bus/'
               }
               json resp
             end
@@ -32,7 +32,7 @@ module Sinatra
               end
               routes = Route.where(route_id: route_ids).map(&:to_v1)
 
-              halt 404, not_found_error('No routes found.', 'https://docs.umd.io/#tags/bus/') if routes == []
+              halt 404, not_found_error('No routes found.', 'https://beta.umd.io/#tags/bus/') if routes == []
               json routes
             end
 
@@ -41,7 +41,7 @@ module Sinatra
               halt 400, bad_url_error(bad_route_message, bus_docs_url) unless is_route_id? route_id
               res = Schedule.where(route: route_id).map(&:to_v1)
 
-              halt 404, not_found_error('No routes found.', 'https://docs.umd.io/#tags/bus/') if res == []
+              halt 404, not_found_error('No routes found.', 'https://beta.umd.io/#tags/bus/') if res == []
               json res
             end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,7 +8,7 @@ module Sinatra
           app.register Sinatra::Namespace
 
           app.namespace '/v1/courses' do
-            course_docs_url = 'https://docs.umd.io/courses/'
+            course_docs_url = 'https://beta.umd.io/courses/'
 
             before do
               @course_params = %w[semester credits dept_id grading_method core gen_ed]

--- a/app/controllers/majors_controller.rb
+++ b/app/controllers/majors_controller.rb
@@ -10,7 +10,7 @@ module Sinatra
               resp = {
                 message: 'This is the majors endpoint.',
                 version: '1.0.0',
-                docs: 'https://docs.umd.io/majors',
+                docs: 'https://beta.umd.io/majors',
                 endpoints: ['/list']
               }
               json resp

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -11,7 +11,7 @@ module Sinatra
               resp = {
                 message: 'This is the map endpoint.',
                 version: '1.0.0',
-                docs: 'https://docs.umd.io/map',
+                docs: 'https://beta.umd.io/map',
                 endpoints: ['/buildings', '/buildings/{:building_id}']
               }
               json resp
@@ -38,7 +38,7 @@ module Sinatra
               resp = {
                 message: 'This is the map endpoint.',
                 status: 'in development',
-                docs: 'https://docs.umd.io/map'
+                docs: 'https://beta.umd.io/map'
               }
               json resp
             end

--- a/app/controllers/professors_controller.rb
+++ b/app/controllers/professors_controller.rb
@@ -55,7 +55,7 @@ module Sinatra
 
               # If no professors found, 404
               if res == []
-                halt 404, not_found_error('There were no professors that matched your search.', 'https://docs.umd.io/#tag/professors')
+                halt 404, not_found_error('There were no professors that matched your search.', 'https://beta.umd.io/#tag/professors')
               end
 
               json res

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -9,7 +9,7 @@ module Sinatra
             resp = {
               message: 'This is the umd.io JSON API.',
               status: 'working, most of the time',
-              docs: 'https://docs.umd.io/',
+              docs: 'https://beta.umd.io/',
               current_version: 'v0',
               versions: [
                 {
@@ -33,27 +33,27 @@ module Sinatra
                 {
                   name: 'Courses',
                   url: 'https://api.umd.io/v1/courses',
-                  docs: 'https://docs.umd.io/#tag/courses'
+                  docs: 'https://beta.umd.io/#tag/courses'
                 },
                 {
                   name: 'Professors',
                   url: 'https://api.umd.io/v1/professors',
-                  docs: 'https://docs.umd.io/#tag/professors'
+                  docs: 'https://beta.umd.io/#tag/professors'
                 },
                 {
                   name: 'Bus',
                   url: 'https://api.umd.io/v1/bus',
-                  docs: 'https://docs.umd.io/#tag/bus'
+                  docs: 'https://beta.umd.io/#tag/bus'
                 },
                 {
                   name: 'Map',
                   url: 'https://api.umd.io/v1/map',
-                  docs: 'https://docs.umd.io/#tag/map'
+                  docs: 'https://beta.umd.io/#tag/map'
                 },
                 {
                   name: 'Majors',
                   url: 'https://api.umd.io/v1/majors',
-                  docs: 'https://docs.umd.io/#tag/majors'
+                  docs: 'https://beta.umd.io/#tag/majors'
                 }
               ]
             }
@@ -96,7 +96,7 @@ module Sinatra
             resp = {
               error_code: 404,
               message: "We couldn't find what you're looking for. Please see the docs for more information.",
-              docs: 'https://docs.umd.io/'
+              docs: 'https://beta.umd.io/'
             }
             status 404
             json resp

--- a/app/helpers/courses_helpers.rb
+++ b/app/helpers/courses_helpers.rb
@@ -25,7 +25,7 @@ module Sinatra
             error_code: 404,
             message: "Section with section_id #{section_ids[0]} not found.",
             available_sections: 'https://api.umd.io/v0/courses/sections',
-            docs: 'https://docs.umd.io/courses'
+            docs: 'https://beta.umd.io/courses'
           }.to_json
         end
 
@@ -38,7 +38,7 @@ module Sinatra
           next if is_full_section_id? id
           return false unless do_halt
 
-          halt 400, bad_url_error("Invalid section_id #{id}.", 'https://docs.umd.io/courses/')
+          halt 400, bad_url_error("Invalid section_id #{id}.", 'https://beta.umd.io/courses/')
         end
 
         true
@@ -53,7 +53,7 @@ module Sinatra
           next if is_course_id? id
           return false unless do_halt
 
-          halt 400, bad_url_error("Invalid course_id #{id}.", 'https://docs.umd.io/courses/')
+          halt 400, bad_url_error("Invalid course_id #{id}.", 'https://beta.umd.io/courses/')
         end
 
         true
@@ -74,7 +74,7 @@ module Sinatra
             error_code: 404,
             message: "Course#{s} with course_id#{s} #{course_ids.join(',')} not found!",
             available_courses: 'https://api.umd.io/v0/courses',
-            docs: 'https://docs.umd.io/courses/'
+            docs: 'https://beta.umd.io/courses/'
           }.to_json
         end
 
@@ -107,7 +107,7 @@ module Sinatra
             error_code: 404,
             message: "Course#{s} with course_id#{s} #{course_ids.join(',')} not found!",
             available_courses: 'https://api.umd.io/v0/courses',
-            docs: 'https://docs.umd.io/courses/'
+            docs: 'https://beta.umd.io/courses/'
           }.to_json
         end
 

--- a/app/helpers/map_helpers.rb
+++ b/app/helpers/map_helpers.rb
@@ -5,7 +5,7 @@ module Sinatra
     module Helpers
       def get_buildings_by_id(id)
         bad_id_message = 'Check the building id in the url.'
-        doc_url = 'https://docs.umd.io/map'
+        doc_url = 'https://beta.umd.io/map'
 
         building_ids = id.upcase.split(',')
         building_ids.each do |building_id|
@@ -20,7 +20,7 @@ module Sinatra
             error_code: 404,
             message: "Building number #{params[:building_id]} isn't in our database, and probably doesn't exist.",
             available_buildings: 'https://api.umd.io/v0/map/buildings',
-            docs: 'https://docs.umd.io/map'
+            docs: 'https://beta.umd.io/map'
           }.to_json
         end
 


### PR DESCRIPTION
most error messages (et al) still directed people to docs.umd.io, even for v1 routes. This changes most docs urls to beta.umd.io, though v0 routes have been left pointing to docs.umd.io where possible.

We probably want to move beta.umd.io to docs.umd.io (since it's the most up to date docs version and no longer a "beta"), and move docs.umd.io to somewhere else, but I don't really want to think about that headache of redirects right now. This is good enough for now.