### PR TITLE
scraper less years with scrape:courses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,11 +116,7 @@ namespace :scrape do
 
   desc 'Run course scrapers'
   task :courses do
-    # Testudo updated in September for Spring, Fed for fall
-    # if fall is updated, we want to get the next year's courses
-    year = Time.now.month <= 9 ? Time.now.year : Time.now.year + 1
-    years = ((year - 3)..year).to_a.join ' '
-    scrape_courses(years)
+    scrape_courses(current_and_next_semesters.join(' '))
   end
 
   desc 'Run course seat updater'


### PR DESCRIPTION
I don't see any need to scrape *three years* of courses with this command, especially since testudo only keeps the most recent 4 semesters or so even available. Best to just scrape the current and upcoming semesters.